### PR TITLE
build(deps): add bs4; fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ See [this blog post](https://blog.langchain.dev/tutorial-chatgpt-over-your-data/
 
 ## Ingest data
 
-Ingestion of data is done over the `state_of_the_union.txt` file. 
-Therefor, the only thing that is needed is to be done to ingest data is run `python ingest_data.py`
+Ingestion of data is done over the `state_of_the_union.txt` file.
+Therefore, the only thing that is needed is to be done to ingest data is run `python ingest_data.py`
 
 ## Query data
 Custom prompts are used to ground the answers in the state of the union text file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+beautifulsoup4
 langchain
 openai
 unstructured


### PR DESCRIPTION
Cool application! Raising a small PR to fix a `README` typo and add `beautifulsoup4` to `requirements.txt`. I get the following `ModuleNotFoundError` if it's not installed.

```
Traceback (most recent call last):
  File "ingest_data.py", line 2, in <module>
    from langchain.document_loaders import UnstructuredFileLoader
  File "/Users/mrobinson/.pyenv/versions/langchain/lib/python3.8/site-packages/langchain/document_loaders/__init__.py", line 3, in <module>
    from langchain.document_loaders.azlyrics import AZLyricsLoader
  File "/Users/mrobinson/.pyenv/versions/langchain/lib/python3.8/site-packages/langchain/document_loaders/azlyrics.py", line 5, in <module>
    from langchain.document_loaders.web_base import WebBaseLoader
  File "/Users/mrobinson/.pyenv/versions/langchain/lib/python3.8/site-packages/langchain/document_loaders/web_base.py", line 5, in <module>
    from bs4 import BeautifulSoup
ModuleNotFoundError: No module named 'bs4'
```