### PR TITLE
fix compilation and runtime errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-langchain
+langchain==0.0.277
 openai
 faiss-cpu
 unstructured
 tiktoken
 rich #for console formatting
-gradio
+gradio==3.40.0


### PR DESCRIPTION
Versions were not specified in requirements.txt, so it gets the latest ones. The latest ones now differ from 3 months ago, so a few runtime errors prevented the app from working. Tried with python 3.9.